### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Eventually, change docker settings `/etc/docker/daemon.json` to define where doc
 
 To install the *KritaBuilder*, you just need to clone repository:
 ```bash
-git clone git@github.com:Grum999/KritaBuilder.git
+git clone https://github.com/Grum999/KritaBuilder.git
 ```
 
 Once repository is cloned, you can check script:
@@ -69,11 +69,12 @@ By default, when creating a new environment, official [*Krita* repository](https
 ./kbuilder new my_build_environment
 ```
 
-If you want to use an alternative repository, you can provide path of local repository from where source have to be used to build *Krita*
+If you want to use an alternative local repository, you can provide provide its location with `--source-path` option:
 > Example to use local repository located in `/home/xxxx/Sources/krita`
 > ```bash
 > ./kbuilder new --source-path=/home/xxxx/Sources/krita my_build_environment
 > ```
+
 
 When an environment is created:
 - Dependencies will be downloaded and built
@@ -94,14 +95,14 @@ All files (source code, binaries, ...) are NOT stored in the docker but in *Krit
 | `.docker-config` | Is the `~/.config` directory of your docker<br>It allows to keep persistent data setup even if Docker is stopped |
 | `appimages` | Is the place where appimages are built |
 | `data` | Is the `~/data` directory of your docker<br>It allows you to access to persistent data from/to the docker (get access from your computer to `.kra` files saved in `~/data` for example) |
-| `sources` | Is the place where *Krita* repsitory will be cloned (if not provided) and dependencies sources will be downloaded |
+| `sources` | Is the place where *Krita* repository will be cloned (if not provided) and dependencies sources will be downloaded |
 | `workspaces` |Is the place where *Krita* build files will be produced |
 
 ### Start and Stop environments
 
 The command **`start`** will start docker for designed build environment, the **stop** command will stop the docker.
 
-> Note: any command that need a *running* docker will automativally start docker if needed.
+> Note: any command that need a *running* docker will automatically start docker if needed.
 
 ### List environments
 
@@ -117,7 +118,7 @@ The command **`remove`** will delete everything related to an environment:
 - Directories
 - Docker
 
-> Note: if a specific *Krita* local repository has been provided (instead of working with and automatic clone), the specific local repository is not removed
+> Note: if a specific *Krita* local repository has been provided (instead of working with and automatic clone), the specific local repository is not removed!
 
 ## Build Krita
 
@@ -137,12 +138,15 @@ Execution is made from the docker.
 
 - Use `--appimage` option to execute last *Krita* appimage built (will not be executed from docker, but directly from your session)
 - Use `--scale` option to change `QT_SCALE_FACTOR` value
+- Use `--debug` option to execute *Krita* with *gdb*, *valgrind* or *callgrind*
 
 ## Check logs
 
 The command **`logs`** let you the ability to show logs produced from the last build execution.
 
 - Use `--full` option to get complete logs
+- Use `--debug` option to get debug logs *if Krita has been executed with `--debug` option*
+
 
 ## Tools
 

--- a/data/src-docker/Dockerfile
+++ b/data/src-docker/Dockerfile
@@ -47,6 +47,7 @@ RUN mkdir -p $KRITA_WS_PATH/krita.appdir/usr && \
     mkdir -p $KRITA_APPIMG_PATH && \
     mkdir -p $USRHOME/build/src/downloads && \
     mkdir -p $USRHOME/.config && \
+    mkdir -p $USRHOME/.config/gdb && \
     mkdir -p $USRHOME/bin && \
     mkdir -p $USRHOME/data
 
@@ -57,6 +58,10 @@ COPY ./home/.bash_devenv \
 COPY ./bin/krita-cmd.sh \
      ./bin/run_cmake.sh \
      $USRHOME/bin/
+
+COPY ./home/debug-short.gdb \
+     ./home/debug-interactive.gdb \
+     $USRHOME/.config/gdb/
 
 RUN chown -R appimage:appimage $USRHOME
 RUN chmod a+rwx /tmp

--- a/data/src-docker/home/.bash_devenv
+++ b/data/src-docker/home/.bash_devenv
@@ -9,6 +9,7 @@ export KRITA_APPIMG_PATH=$KRITA_BUILD_PATH/appimages
 
 
 export KRITADIR=$KRITA_WS_PATH/krita.appdir/usr
+export KRITADIR_BIN=$KRITADIR/bin/krita
 export DEPSDIR=$KRITA_WS_PATH/deps/usr
 export QML2_IMPORT_PATH=$KRITADIR/lib/x86_64-linux-gnu/qml
 

--- a/data/src-docker/home/debug-interactive.gdb
+++ b/data/src-docker/home/debug-interactive.gdb
@@ -1,0 +1,2 @@
+set pagination off
+set logging file ~/build/.gdb-output

--- a/data/src-docker/home/debug-short.gdb
+++ b/data/src-docker/home/debug-short.gdb
@@ -1,0 +1,9 @@
+set pagination off
+set logging file ~/build/.gdb-output
+set logging on
+
+run
+thread apply all bt
+
+set logging off
+quit

--- a/data/src-inc/docker.inc
+++ b/data/src-inc/docker.inc
@@ -204,11 +204,14 @@ function dockerContainerRun() {
         OPT_KVM+="--device /dev/kvm"
     fi
 
-
-    DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/data:$APPIMG_USER_HOME/data:rw"
+    DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/data-env:$APPIMG_USER_HOME/data-env:rw"
     DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/appimages:$APPIMG_KRITA_APPIMG_PATH:rw"
     DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/.docker-config/mc:$APPIMG_USER_HOME/.config/mc:rw"
     DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/.docker-config/htop:$APPIMG_USER_HOME/.config/htop:rw"
+
+    if [ "$DATA_PATH" != "" ]; then
+        DOCKER_MOUNTS="$DOCKER_MOUNTS -v $DATA_PATH:$APPIMG_USER_HOME/data:rw"
+    fi
 
     if [[ -d $ENV_PATH/sources/downloads ]]; then
         DOCKER_MOUNTS="$DOCKER_MOUNTS -v $ENV_PATH/sources/downloads:$APPIMG_KRITA_WS_PATH/downloads:rw"
@@ -465,5 +468,4 @@ function dockerContainerExec() {
     # execute a command on a container
     #
     ${DOCKER_BINARY} container exec $@
-
 }

--- a/data/src-inc/environments.inc
+++ b/data/src-inc/environments.inc
@@ -96,6 +96,7 @@ function environmentCreate() {
     # create environment
     # $1 = name
     # $2 = source path/url
+    # $3 = data path
     #
     # - create directories
     # - create defaults files
@@ -104,12 +105,13 @@ function environmentCreate() {
     local OPT_QUIET=
     local ENV_NAME=$1
     local KRITA_SRC=$2
+    local DATA_PATH=$3
     local ENV_PATH="$(environmentPathName $ENV_NAME)"
     local CFG_FILE="$(environmentConfigFile $ENV_NAME)"
     local DIRECTORIES=("$ENV_PATH/appimages"
                        "$ENV_PATH/sources/downloads"
                        "$ENV_PATH/sources/krita"
-                       "$ENV_PATH/data"
+                       "$ENV_PATH/data-env"
                        "$ENV_PATH/workspace/deps/usr"
                        "$ENV_PATH/workspace/krita.appdir/usr"
                        "$ENV_PATH/workspace/krita-build"
@@ -126,6 +128,7 @@ function environmentCreate() {
 
     # -- create default files
     echo "KRITA_SRC=$KRITA_SRC" > $CFG_FILE
+    echo "DATA_PATH=$DATA_PATH" >> $CFG_FILE
     echo "QT_SCALE_FACTOR=1.0" >> $CFG_FILE
 
     if [[ "$KRITA_SRC" =~ ^https?:// ]]; then

--- a/kbuilder
+++ b/kbuilder
@@ -7,7 +7,7 @@
 
 # KBuilder Version
 KBUILDER_NAME=KBuilder
-KBUILDER_VERSION=1.0.0
+KBUILDER_VERSION=1.1.0
 
 # current directory
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -162,6 +162,8 @@ function commandHelp() {
     -cREF,      --clone=REF         Create a new build environment by cloning REF environment
                                     Doing a clone is faster as download & build information are
                                     already available
+    -dPATH,     --data-path=PATH    Full path to alternative data path
+                                    Given path will be available in docker ~/data directory
     -sPATH,     --source-path=PATH  Full path to Krita source files
                                     Can be also an url to a git repository
                                     If not provided, installer will automatically
@@ -268,6 +270,11 @@ function commandHelp() {
   Execute Krita from environment
 
     -h,         --help              Display this help message
+    -dTOOL,     --debug=TOOL        Execute Krita debugger
+                                    Available debbuger tool can be:
+                                    - gdb
+                                    - valgrind
+                                    - callgrind (by default it will start 'off')
     -a,         --appimage          Run last built appimage, if any
     -sFACTOR,   --scale=FACTOR      Define scale factor for UI
 
@@ -281,6 +288,7 @@ function commandHelp() {
     -h,         --help              Display this help message
     -f,         --full              Display full log
     -t,         --time              Display execution times
+    -d,         --debug             Display debug logs, if any
     -oEDITOR,   --open=EDITOR       Open logs wih given editor
                                     Available editors
                                     - emacs
@@ -304,6 +312,9 @@ function commandHelp() {
     - bash                          Enter in shell; default tool if none is specified
     - mc                            Execue Midnight Commander
     - htop                          Execute htop
+    - gdb                           Execute gdb in interactive mode (run command will start Krita)
+    - callgrind-on                  When Krita is executed with debugger callgrind, allows to start analysis
+    - callgrind-off                 When Krita is executed with debugger callgrind, allows to stop analysis
   "
     else
         USAGE="Unknown command: $1"
@@ -343,7 +354,7 @@ function commandNone() {
 function commandNew() {
     COMMAND="$1"
     shift
-    ARGS=$(checkArgs "$COMMAND" "hc:s:v" "help,clone:,source-path:,verbose,no-build,no-cache" "$(getDefaultArgs $COMMAND) $@") || exit $?
+    ARGS=$(checkArgs "$COMMAND" "hc:s:d:v" "help,clone:,source-path:,data-path:,verbose,no-build,no-cache" "$(getDefaultArgs $COMMAND) $@") || exit $?
     eval set -- "$ARGS"
 
     if [ $# -eq 1 ]; then
@@ -355,6 +366,7 @@ function commandNew() {
     OPT_NO_BUILD=0
     OPT_CLONE_FROM=
     OPT_SOURCE_PATH="https://invent.kde.org/graphics/krita.git"
+    OPT_DATA_PATH=""
     OPT_ENVNAME=
 
     while true; do
@@ -366,6 +378,10 @@ function commandNew() {
             -c | --clone)
                 shift
                 OPT_CLONE_FROM=$1
+                ;;
+            -d | --data-path)
+                shift
+                OPT_DATA_PATH=$1
                 ;;
             -s | --source-path)
                 shift
@@ -448,7 +464,17 @@ function commandNew() {
         displayOk
     fi
 
-    environmentCreate $ENVIRONMENT_NAME $OPT_SOURCE_PATH || exit 1
+    if [[ "$OPT_DATA_PATH" != "" ]]; then
+        displayStep "Check data directory"
+        if [ ! -d "$OPT_DATA_PATH" ]; then
+            displayKo
+            displayNfo "Path not found: $OPT_DATA_PATH"
+            return 1
+        fi
+        displayOk
+    fi
+
+    environmentCreate $ENVIRONMENT_NAME $OPT_SOURCE_PATH $OPT_DATA_PATH || exit 1
     dockerImageCreate $ENVIRONMENT_NAME $OPT_NO_CACHE || exit 1
     dockerContainerRun $ENVIRONMENT_NAME || exit 1
     environmentLastStarted ADD $ENVIRONMENT_NAME
@@ -1107,6 +1133,16 @@ function commandBuild() {
         fi
     fi
 
+    displayStep "Current Git repository"
+    displayNfo ""
+
+    GITNFO=$(dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC buildGitNfo)
+    IFS=$'\n'
+    for nfo in $GITNFO
+    do
+        displayNfo $nfo
+    done
+
     displayStep "Build Krita"
     if [ $OPT_VERBOSE -gt 1 ]; then
         displayNfo ""
@@ -1143,7 +1179,7 @@ function commandBuild() {
     fi
 
     if [ $OPT_RUN_KRITA -eq 1 ]; then
-        commandKrita commandKrita
+        commandKrita krita $ENVIRONMENT_NAME
     fi
 
     return $?
@@ -1153,11 +1189,12 @@ function commandKrita() {
     COMMAND="$1"
     shift
 
-    ARGS=$(checkArgs "$COMMAND" "has:" "help,appimage,scale:" "$(getDefaultArgs $COMMAND) $@") || exit $?
+    ARGS=$(checkArgs "$COMMAND" "has:d:" "help,appimage,scale:,debug:" "$(getDefaultArgs $COMMAND) $@") || exit $?
     eval set -- "$ARGS"
 
     OPT_APPIMG=0
     OPT_SCALE=
+    OPT_DEBUG=
 
     while true; do
         case "$1" in
@@ -1167,6 +1204,10 @@ function commandKrita() {
                 ;;
             -a | --appimage)
                 OPT_APPIMG=1
+                ;;
+            -d | --debug)
+                shift
+                OPT_DEBUG=$1
                 ;;
             -s | --scale)
                 shift
@@ -1185,7 +1226,8 @@ function commandKrita() {
 
     displayHeader "Start Krita"
 
-    ENVIRONMENT_NAME=$1
+    # trim leading spaces, not sure why there's one :)
+    ENVIRONMENT_NAME=${1# }
 
     source ${CINCDIR}/environments.inc
     source ${CINCDIR}/docker.inc
@@ -1235,11 +1277,25 @@ function commandKrita() {
 
         OPT_KRITA=""
         if [ "$OPT_SCALE" != "" ]; then
-            OPT_KRITA="--scale=$OPT_SCALE"
+            OPT_KRITA=" --scale=$OPT_SCALE"
         fi
 
-        dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC kritaExec "$OPT_KRITA"
+        if [ "$OPT_DEBUG" == "gdb" ]; then
+            OPT_DEBUG="--debug=gdb"
+        elif [ "$OPT_DEBUG" == "valgrind" ]; then
+            OPT_DEBUG="--debug=valgrind"
+        elif [ "$OPT_DEBUG" == "callgrind" ]; then
+            OPT_DEBUG="--debug=callgrind"
+        else
+            OPT_DEBUG=
+        fi
+
+        dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC kritaExec $OPT_DEBUG "$OPT_KRITA"
     else
+        if [ "$OPT_DEBUG" != "" ]; then
+            displayNfo ".. Warning: can't debug AppImage"
+        fi
+
         if [ "$OPT_SCALE" != "" ]; then
             export QT_SCALE_FACTOR=$OPT_SCALE
         fi
@@ -1271,12 +1327,13 @@ function commandLogs() {
     COMMAND="$1"
     shift
 
-    ARGS=$(checkArgs "$COMMAND" "hfto:" "help,full,time,open:" "$(getDefaultArgs $COMMAND) $@") || exit $?
+    ARGS=$(checkArgs "$COMMAND" "hfto:d" "help,full,time,open:,debug" "$(getDefaultArgs $COMMAND) $@") || exit $?
     eval set -- "$ARGS"
 
     OPT_MODE=short
     OPT_OPEN=cat
     OPT_TIME=N
+    OPT_DEBUG=N
 
     while true; do
         case "$1" in
@@ -1293,6 +1350,9 @@ function commandLogs() {
             -o | --open)
                 shift
                 OPT_OPEN=$1
+                ;;
+            -d | --debug)
+                OPT_DEBUG=Y
                 ;;
             --)
                 shift
@@ -1345,11 +1405,11 @@ function commandLogs() {
     case "$OPT_OPEN" in
         'cat')
             displayNfo ""
-            dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC buildLogGet $OPT_MODE $OPT_TIME $OPT_OPEN
+            dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC buildLogGet $OPT_MODE $OPT_TIME $OPT_DEBUG $OPT_OPEN
             ;;
         'emacs' | 'mcedit' | 'nano'  | 'vi' | 'vim')
             displayNfo "start $OPT_OPEN"
-            dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC buildLogGet $OPT_MODE $OPT_TIME $OPT_OPEN
+            dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC buildLogGet $OPT_MODE $OPT_TIME $OPT_DEBUG $OPT_OPEN
             ;;
         *)
             display "unknown editor"
@@ -1389,7 +1449,7 @@ function commandTool() {
     displayHeader "Execute tool"
 
     case "$1" in
-        'bash' | 'mc' | 'htop')
+        'bash' | 'mc' | 'htop' | 'gdb' | 'callgrind-on' | 'callgrind-off')
             # environment ommited, only tool is provided
             ENVIRONMENT_NAME=
             ;;
@@ -1447,6 +1507,39 @@ function commandTool() {
                 displayStep "Execute $TLS_NAME"
                 display
                 dockerContainerExec -ti $ENVIRONMENT_NAME $TLS_NAME
+            fi
+            ;;
+        'gdb')
+            if [ "$OPT_ROOT" == "Y" ]; then
+                displayStep "Execute $TLS_NAME (as root)"
+                display
+                dockerContainerExec -ti -u $ENVIRONMENT_NAME $KRITA_EXEC gdbExec
+            else
+                displayStep "Execute $TLS_NAME"
+                display
+                dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC gdbExec
+            fi
+            ;;
+        'callgrind-on')
+            if [ "$OPT_ROOT" == "Y" ]; then
+                displayStep "Execute $TLS_NAME (as root)"
+                display
+                dockerContainerExec -ti -u $ENVIRONMENT_NAME $KRITA_EXEC callgrindExec --start
+            else
+                displayStep "Execute $TLS_NAME"
+                display
+                dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC callgrindExec --start
+            fi
+            ;;
+        'callgrind-off')
+            if [ "$OPT_ROOT" == "Y" ]; then
+                displayStep "Execute $TLS_NAME (as root)"
+                display
+                dockerContainerExec -ti -u $ENVIRONMENT_NAME $KRITA_EXEC callgrindExec --stop
+            else
+                displayStep "Execute $TLS_NAME"
+                display
+                dockerContainerExec -ti $ENVIRONMENT_NAME $KRITA_EXEC callgrindExec --stop
             fi
             ;;
         *)


### PR DESCRIPTION
Improve kbuilder
    * action: new
        . add --data-path option, to let the container being able to access to an external location where persistent Krita
        documents can be saved/loaded
    
    * action: build
        . fix --run option
    
    * action: krita
        . add --debug option, to let run Krita with debugger: gdb, valgrind, callgrind
    
    * action: log
        . add option --debug, to let being able to access to logs produced by debugger
    
    * action: tool
        . add 'gdb' tool, to access to gdb in interactive mode
        . add 'callgrind-on' & 'callgrind-off' to allows to activate/deactivate callgrind analysis
    
Update Dockerfile
    * manage gdb configurations
